### PR TITLE
Incorrect Speaking As Redundancy

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -130,10 +130,6 @@
 			{
 				"id": "simply-portraits",
 				"reason": "Redundancy of features you can disable 'Simply Portraits' module if you want"
-			},
-			{
-				"id": "speaking-as",
-				"reason": "Redundancy of features you can disable 'Speaking As' module if you want"
 			}
 		]
 	}


### PR DESCRIPTION
Speaking As does not add any kind of Chat Portraits to the messages, and as such the two modules are not related at all. 
You may be thinking of PF2e Dorako UI, which has a much bigger support for avatar specifically for PF2e.