### PR TITLE
Mark module compatible with v14

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -98,8 +98,8 @@
     ],
     "compatibility": {
         "minimum": 13,
-        "verified": 13,
-        "maximum": 13
+        "verified": 14,
+        "maximum": 14
     },
     "url": "https://github.com/p4535992/foundryvtt-chat-portrait",
     "manifest": "https://github.com/p4535992/foundryvtt-chat-portrait/releases/download/13.0.2/module.json",


### PR DESCRIPTION
Updates the version markers to include Foundry v14. Fixes #62.

I tried it and it seems to work fine. No new messages in the console, and the behavior I know how to look for is working (mostly defaults, showing portraits, border colors for chat messages, etc).